### PR TITLE
Move IAppointment to Core project.

### DIFF
--- a/BlazorScheduler.sln
+++ b/BlazorScheduler.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 17.0.31423.177
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorScheduler", "BlazorScheduler\BlazorScheduler.csproj", "{7B925AA6-DC1F-4E9F-8E1E-B57E344AA43D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DemoApp", "DemoApp\DemoApp.csproj", "{5FA9FE4D-C4C7-4A49-A10B-5B84E15D33E7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DemoApp", "DemoApp\DemoApp.csproj", "{5FA9FE4D-C4C7-4A49-A10B-5B84E15D33E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorScheduler.Core", "BlazorSchedulerCore\BlazorScheduler.Core.csproj", "{3F0AABE4-9274-4C6B-803A-748E80CEFAF1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{5FA9FE4D-C4C7-4A49-A10B-5B84E15D33E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5FA9FE4D-C4C7-4A49-A10B-5B84E15D33E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5FA9FE4D-C4C7-4A49-A10B-5B84E15D33E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F0AABE4-9274-4C6B-803A-748E80CEFAF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F0AABE4-9274-4C6B-803A-748E80CEFAF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F0AABE4-9274-4C6B-803A-748E80CEFAF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F0AABE4-9274-4C6B-803A-748E80CEFAF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BlazorScheduler/BlazorScheduler.csproj
+++ b/BlazorScheduler/BlazorScheduler.csproj
@@ -1,23 +1,22 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>John Valincius</Authors>
     <Company>Valincius</Company>
     <Description>Scheduler component library for Blazor.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/valincius/BlazorScheduler</RepositoryUrl>
-    <Version>1.0.2</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
-
 
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlazorScheduler.Core" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="5.0.*" />
   </ItemGroup>
 

--- a/BlazorScheduler/Internal/Components/SchedulerAllDayAppointment.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerAllDayAppointment.razor.cs
@@ -1,4 +1,5 @@
-﻿using BlazorScheduler.Internal.Extensions;
+﻿using BlazorScheduler.Core;
+using BlazorScheduler.Internal.Extensions;
 using Microsoft.AspNetCore.Components;
 using System.Collections.Generic;
 

--- a/BlazorScheduler/Internal/Components/SchedulerAppointment.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerAppointment.razor.cs
@@ -1,4 +1,5 @@
-﻿using BlazorScheduler.Internal.Extensions;
+﻿using BlazorScheduler.Core;
+using BlazorScheduler.Internal.Extensions;
 using Microsoft.AspNetCore.Components;
 
 namespace BlazorScheduler.Internal.Components

--- a/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using BlazorScheduler.Core;
+using Microsoft.AspNetCore.Components;
 using System.Collections.Generic;
 
 namespace BlazorScheduler.Internal.Components

--- a/BlazorScheduler/Internal/Components/SchedulerDay.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerDay.razor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using BlazorScheduler.Internal.Extensions;
 using Microsoft.AspNetCore.Components.Web;
+using BlazorScheduler.Core;
 
 namespace BlazorScheduler.Internal.Components {
 	public partial class SchedulerDay<T> where T : IAppointment, new() {

--- a/BlazorScheduler/Internal/Components/SchedulerWeek.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerWeek.razor.cs
@@ -1,4 +1,5 @@
-﻿using BlazorScheduler.Internal.Extensions;
+﻿using BlazorScheduler.Core;
+using BlazorScheduler.Internal.Extensions;
 using Microsoft.AspNetCore.Components;
 using System;
 using System.Collections.Generic;

--- a/BlazorScheduler/Scheduler.razor.cs
+++ b/BlazorScheduler/Scheduler.razor.cs
@@ -8,6 +8,7 @@ using BlazorScheduler.Internal.Extensions;
 using BlazorScheduler.Internal.Components;
 using System.Drawing;
 using Microsoft.AspNetCore.Components.Web;
+using BlazorScheduler.Core;
 
 namespace BlazorScheduler
 {

--- a/BlazorSchedulerCore/BlazorScheduler.Core.csproj
+++ b/BlazorSchedulerCore/BlazorScheduler.Core.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Authors>John Valincius</Authors>
+    <Company>Valincius</Company>
+    <Description>Core library for BlazorScheduler containing necessary classes and interfaces.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl></PackageProjectUrl>
+    <RepositoryUrl>https://github.com/valincius/BlazorScheduler</RepositoryUrl>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/BlazorSchedulerCore/IAppointment.cs
+++ b/BlazorSchedulerCore/IAppointment.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Drawing;
 
-namespace BlazorScheduler
+namespace BlazorScheduler.Core
 {
 	public interface IAppointment
 	{

--- a/DemoApp/Pages/Index.razor
+++ b/DemoApp/Pages/Index.razor
@@ -1,6 +1,8 @@
 ﻿@page "/"
-@using BlazorScheduler
 @using System.Drawing
+
+@using BlazorScheduler
+@using BlazorScheduler.Core
 
 @inject HttpClient HttpClient
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ The scheduler supports "all-day" appointments, appointments spanning multiple da
 Also has support for dragging to create appointments.
 
 ## Usage
-1. Add `BlazorScheduler` NuGet package
+1. Run `Install-Package BlazorScheduler` in the package manager console to install the latest package in your frontend project.
+    - Optionally run `Install-Package BlazorScheduler.Core` in your shared project so you can have access to the interfaces there.
 2. Add references to necessary js & css files in your `index.html`
     - Add `<link href="_content/BlazorScheduler/css/styles.css" rel="stylesheet" />` to the head
     - Add `<script src="_content/BlazorScheduler/js/scripts.js"></script>` to the body
 3. Add `@using BlazorScheduler` to your page
+    - Add `using BlazorScheduler.Core` wherever you are creating an implementation of `BlazorScheduler.Core.IAppointment`
 4. Create an implementation of `IAppointment`
     ```c#
     public class Appointment : IAppointment
@@ -42,3 +44,16 @@ There are 3 callbacks that the scheduler provides.
 - `Task OnOverflowAppointmentClick(IEnumerable<T> appointments, MouseEventArgs mouse)` - invoked when the user clicks on an "overflowing" appointment
 
 See the demo [here](https://valincius.dev/BlazorScheduler/) for more information on usage
+
+# Changlog
+## 2.0.0
+- Created `BlazorScheduler.Core` project
+    - This project will contain any classes/interfaces that may be required outside of the main UI project.
+- Moved `IAppointment` from `BlazorScheduler` to `BlazorScheduler.Core`
+- **You will need to add `using BlazorScheduler.Core` to where you are creating your implementation of `IAppointment`**
+## 1.0.2
+- Fix bug introduced in 1.0.1
+## 1.0.1
+- Add start day of week parameter to Scheduler
+## 1.0.0
+- Initial release


### PR DESCRIPTION
- Created `BlazorScheduler.Core` project
    - This project will contain any classes/interfaces that may be required outside of the main UI project.
- Moved `IAppointment` from `BlazorScheduler` to `BlazorScheduler.Core`
- **You will need to add `using BlazorScheduler.Core` to where you are creating your implementation of `IAppointment`**