### PR TITLE
[Feature] Appointments creation even when dragging is disabled.

### DIFF
--- a/BlazorScheduler/BlazorScheduler.csproj
+++ b/BlazorScheduler/BlazorScheduler.csproj
@@ -10,7 +10,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl></PackageProjectUrl>
     <RepositoryUrl>https://github.com/valincius/BlazorScheduler</RepositoryUrl>
-    <Version>4.3.0</Version>
+    <Version>4.3.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorScheduler/Components/Scheduler.razor.cs
+++ b/BlazorScheduler/Components/Scheduler.razor.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.AspNetCore.Components;
+﻿using BlazorScheduler.Internal.Components;
+using BlazorScheduler.Internal.Extensions;
+using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-using BlazorScheduler.Internal.Extensions;
-using BlazorScheduler.Internal.Components;
-using System.Collections.ObjectModel;
 
 namespace BlazorScheduler
 {
@@ -24,6 +24,7 @@ namespace BlazorScheduler
         [Parameter] public bool AlwaysShowYear { get; set; } = true;
         [Parameter] public int MaxVisibleAppointmentsPerDay { get; set; } = 5;
         [Parameter] public bool EnableDragging { get; set; } = true;
+        [Parameter] public bool EnableAppointmentsCreationFromScheduler { get; set; } = true;
         [Parameter] public bool EnableRescheduling { get; set; }
         [Parameter] public string ThemeColor { get; set; } = "aqua";
         [Parameter] public DayOfWeek StartDayOfWeek { get; set; } = DayOfWeek.Sunday;
@@ -167,13 +168,13 @@ namespace BlazorScheduler
 
         public void BeginDrag(SchedulerDay day)
         {
-            if (!EnableDragging)
+            if (!EnableAppointmentsCreationFromScheduler)
                 return;
 
             _draggingStart = _draggingEnd = day.Day;
             _showNewAppointment = true;
 
-            _draggingAppointmentAnchor = _draggingStart;
+            _draggingAppointmentAnchor = EnableDragging ? _draggingStart : null;
             StateHasChanged();
         }
 

--- a/BlazorScheduler/Components/Scheduler.razor.cs
+++ b/BlazorScheduler/Components/Scheduler.razor.cs
@@ -174,7 +174,7 @@ namespace BlazorScheduler
             _draggingStart = _draggingEnd = day.Day;
             _showNewAppointment = true;
 
-            _draggingAppointmentAnchor = EnableDragging ? _draggingStart : null;
+            _draggingAppointmentAnchor = _draggingStart;
             StateHasChanged();
         }
 
@@ -212,7 +212,7 @@ namespace BlazorScheduler
         [JSInvokable]
         public void OnMouseMove(string date)
         {
-            if (_showNewAppointment && _draggingAppointmentAnchor is not null)
+            if (_showNewAppointment && EnableDragging)
             {
                 var day = DateTime.ParseExact(date, "yyyyMMdd", null);
                 (_draggingStart, _draggingEnd) = day < _draggingAppointmentAnchor ? (day, _draggingAppointmentAnchor.Value) : (_draggingAppointmentAnchor.Value, day);

--- a/BlazorScheduler/Components/Scheduler.razor.cs
+++ b/BlazorScheduler/Components/Scheduler.razor.cs
@@ -215,7 +215,8 @@ namespace BlazorScheduler
             if (_showNewAppointment && EnableDragging)
             {
                 var day = DateTime.ParseExact(date, "yyyyMMdd", null);
-                (_draggingStart, _draggingEnd) = day < _draggingAppointmentAnchor ? (day, _draggingAppointmentAnchor.Value) : (_draggingAppointmentAnchor.Value, day);
+                var anchor = _draggingAppointmentAnchor!.Value;
+                (_draggingStart, _draggingEnd) = day < anchor ? (day, anchor) : (anchor, day);
                 StateHasChanged();
             }
 

--- a/DemoApp/Pages/Configuration.razor
+++ b/DemoApp/Pages/Configuration.razor
@@ -9,6 +9,9 @@
     <MudCardContent>
         <MudGrid>
             <MudItem xs="12" md="6">
+                <MudCheckBox @bind-Checked="_enableAppCreationFromScheduler" Label="Enable Appointments creation from scheduler" />
+            </MudItem>
+            <MudItem xs="12" md="6">
                 <MudCheckBox @bind-Checked="_enableDragging" Label="Enable Dragging" />
             </MudItem>
             <MudItem xs="12" md="6">
@@ -59,7 +62,8 @@
     StartDayOfWeek="_startDayOfWeek"
     TodayButtonText="@_todayButtonText"
     PlusOthersText="@_plusOthersText"
-    NewAppointmentText="@_newAppointmentText">
+    NewAppointmentText="@_newAppointmentText"
+    EnableAppointmentsCreationFromScheduler="@_enableAppCreationFromScheduler">
     <Appointments>
         @foreach (var app in _appointments)
         {
@@ -75,6 +79,7 @@
 
     private Scheduler _scheduler;
 
+    private bool _enableAppCreationFromScheduler = true;
     private bool _alwaysShowYear = true;
     private int _maxVisibleAppointmentsPerDay = 5;
     private bool _enableDragging = true;


### PR DESCRIPTION
With this feature, the scheduler component has a new parameter (set to true by default) that allows creating appointments even when the dragging is disabled, but for ONLY the day selected. When this new parameter is set to false, the creation of appointments FROM the scheduler is disabled, and in order to create a new appointment, the user must have a form or another kind of input.