### PR TITLE
Add setting custom classes and styles to appointments

### DIFF
--- a/BlazorScheduler/Components/Appointment.cs
+++ b/BlazorScheduler/Components/Appointment.cs
@@ -17,6 +17,8 @@ namespace BlazorScheduler
         [Parameter] public DateTime Start { get; set; }
         [Parameter] public DateTime End { get; set; }
         [Parameter] public string? Color { get; set; }
+        [Parameter] public string? Class { get; set; }
+        [Parameter] public string? Style { get; set; }
 
         private bool _isVisible = true;
         public bool IsVisible

--- a/BlazorScheduler/Components/Scheduler.razor
+++ b/BlazorScheduler/Components/Scheduler.razor
@@ -76,7 +76,7 @@
             @foreach (var week in GetDaysInRange().Chunk(7))
             {
                 var (start, end) = (week.First(), week.Last());
-                <SchedulerWeek Start="start" End="end" Appointments="GetAppointmentsInRange(start, end)" @key="week" />
+                <SchedulerWeek Start="start" End="end" Appointments="GetAppointmentsInRange(start, end)" @key="week"/>
             }
         </CascadingValue>
     </div>

--- a/BlazorScheduler/Components/Scheduler.razor.cs
+++ b/BlazorScheduler/Components/Scheduler.razor.cs
@@ -15,7 +15,7 @@ namespace BlazorScheduler
         [Parameter] public RenderFragment Appointments { get; set; } = null!;
         [Parameter] public RenderFragment<Scheduler>? HeaderTemplate { get; set; }
         [Parameter] public RenderFragment<DateTime>? DayTemplate { get; set; }
-        [Parameter] public string? RootDaysStyle { get; set; }
+        [Parameter] public string? RootDaysGroupInWeekStyle { get; set; }
         [Parameter] public string? RootAppointmentOverflowStyle { get; set; }
         [Parameter] public string? RootDayClass { get; set; }
         [Parameter] public string? RootDayStyle { get; set; }

--- a/BlazorScheduler/Components/Scheduler.razor.cs
+++ b/BlazorScheduler/Components/Scheduler.razor.cs
@@ -15,7 +15,10 @@ namespace BlazorScheduler
         [Parameter] public RenderFragment Appointments { get; set; } = null!;
         [Parameter] public RenderFragment<Scheduler>? HeaderTemplate { get; set; }
         [Parameter] public RenderFragment<DateTime>? DayTemplate { get; set; }
-
+        [Parameter] public string? RootDaysStyle { get; set; }
+        [Parameter] public string? RootAppointmentOverflowStyle { get; set; }
+        [Parameter] public string? RootDayClass { get; set; }
+        [Parameter] public string? RootDayStyle { get; set; }
         [Parameter] public Func<DateTime, DateTime, Task>? OnRequestNewData { get; set; }
         [Parameter] public Func<DateTime, DateTime, Task>? OnAddingNewAppointment { get; set; }
         [Parameter] public Func<DateTime, Task>? OnOverflowAppointmentClick { get; set; }

--- a/BlazorScheduler/Internal/Components/SchedulerAllDayAppointment.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerAllDayAppointment.razor
@@ -1,7 +1,7 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
-<div class="appointment @Classes.AsString()"
-    style="--start: @Start; --end: @End; --order: @Order; background-color: @Appointment.Color;"
+<div class="appointment @Classes.AsString() @Appointment.Class"
+    style="--start: @Start; --end: @End; --order: @Order; background-color: @Appointment.Color; @Appointment.Style"
     @onmousedown="OnMouseDown" @onmouseup="OnMouseUp" @onmousemove="OnMouseMove">
     @Appointment.RenderChildContent()
 </div>

--- a/BlazorScheduler/Internal/Components/SchedulerAppointment.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerAppointment.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
-<div class="appointment appointment-timed @Classes.AsString()" style="--start: @Start; --order: @Order;" @onmousedown="OnMouseDown" @onmouseup="OnMouseUp" @onmousemove="OnMouseMove">
+<div class="appointment appointment-timed @Classes.AsString() @Appointment.Class" style="--start: @Start; --order: @Order; @Appointment.Style" @onmousedown="OnMouseDown" @onmouseup="OnMouseUp" @onmousemove="OnMouseMove">
     <span class="dot" style="background-color: @Appointment.Color;"></span>
     @Appointment.RenderChildContent()
 </div>

--- a/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor
@@ -1,5 +1,5 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
-<div class="appointment" style="--start: @Start; --end: @Start; --order: @Order;" @onclick="e => Task.FromResult(Scheduler.OnOverflowAppointmentClick?.Invoke(Day))">
+<div class="appointment" style="--start: @Start; --end: @Start; --order: @Order; @Style" @onclick="e => Task.FromResult(Scheduler.OnOverflowAppointmentClick?.Invoke(Day))">
     @Scheduler.PlusOthersText.Replace("{n}", AppointmentCount.ToString())
 </div>

--- a/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor.cs
+++ b/BlazorScheduler/Internal/Components/SchedulerAppointmentOverflow.razor.cs
@@ -11,5 +11,6 @@ namespace BlazorScheduler.Internal.Components
 		[Parameter] public int AppointmentCount { get; set;}
 		[Parameter] public int Start { get; set; }
 		[Parameter] public int Order { get; set; }
+		[Parameter] public string? Style { get; set; }
 	}
 }

--- a/BlazorScheduler/Internal/Components/SchedulerDay.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerDay.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
-<div class="day @Classes.AsString()" @onmousedown="OnMouseDown" data-date="@Day.Date.ToString("yyyyMMdd")">
+<div class="day @Classes.AsString() @Scheduler.RootDayClass" style="@Scheduler.RootDayStyle" @onmousedown="OnMouseDown" data-date="@Day.Date.ToString("yyyyMMdd")">
     @if (Scheduler.DayTemplate != null)
     {
         @Scheduler.DayTemplate(Day)

--- a/BlazorScheduler/Internal/Components/SchedulerWeek.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerWeek.razor
@@ -1,10 +1,10 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
 <div class="week">
-    <div class="days" style="--maxAppointments: @MaxVisibleAppointmentsThisWeek">
+    <div class="days" style="--maxAppointments: @MaxVisibleAppointmentsThisWeek; @Scheduler.RootDaysStyle">
         @for (var dt = Start; dt <= End; dt = dt.AddDays(1))
         {
-            <SchedulerDay Day="dt" @key="dt" />
+            <SchedulerDay Day="dt" @key="dt"/>
         }
     </div>
 
@@ -39,7 +39,7 @@
                     AppointmentCount="numOverFlowAppointments"
                     Start="(dt.DayOfWeek - Scheduler.StartDayOfWeek + 7) % 7"
                     Order="MaxNumOfAppointmentsPerDay"
-                    @key="dt" />
+                    @key="dt" Style="@Scheduler.RootAppointmentOverflowStyle" />
             }
         }
     </div>

--- a/BlazorScheduler/Internal/Components/SchedulerWeek.razor
+++ b/BlazorScheduler/Internal/Components/SchedulerWeek.razor
@@ -1,7 +1,7 @@
 ﻿@namespace BlazorScheduler.Internal.Components
 
 <div class="week">
-    <div class="days" style="--maxAppointments: @MaxVisibleAppointmentsThisWeek; @Scheduler.RootDaysStyle">
+    <div class="days" style="--maxAppointments: @MaxVisibleAppointmentsThisWeek; @Scheduler.RootDaysGroupInWeekStyle">
         @for (var dt = Start; dt <= End; dt = dt.AddDays(1))
         {
             <SchedulerDay Day="dt" @key="dt"/>

--- a/BlazorScheduler/wwwroot/css/styles.css
+++ b/BlazorScheduler/wwwroot/css/styles.css
@@ -65,7 +65,7 @@
 .scheduler > .month > .week > .days {
     display: flex;
     justify-content: space-around;
-    height: max(8.313rem, calc(1.5rem + 5px + 8px + var(--maxAppointments) * 1.2rem));
+    height: max(8.313rem, calc(1.5rem + 5px + 8px + var(--maxAppointments) * 1.5rem));
 }
 
 .scheduler > .month > .week.header {
@@ -120,12 +120,12 @@
 .scheduler > .month > .week > .appointments > .appointment {
     position: absolute;
     left: calc(var(--start) / 7 * 100%);
-    top: max(10px, calc(15px + (var(--order) * 1.2rem)));
+    top: max(10px, calc(15px + (var(--order) * 1.5rem)));
     border-radius: 2px;
     margin-left: 2px;
     width: calc((var(--end) - var(--start) + 1) / 7 * 100% - 4px);
     padding-left: 4px;
-    font-size: .75rem;
+    font-size: .95rem;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/DemoApp/AppointmentService.cs
+++ b/DemoApp/AppointmentService.cs
@@ -15,7 +15,7 @@ namespace DemoApp
 
         private readonly List<AppointmentDto> AllAppointments = new()
         {
-            new AppointmentDto { Title = "Hello 1", Start = DateTime.Now, End = DateTime.Now.AddHours(1), Color = "yellow" },
+            new AppointmentDto { Title = "Hello 1", Start = DateTime.Now, End = DateTime.Now.AddHours(1), Color = "yellow", Class = "bg-dark text-white"},
             new AppointmentDto { Title = "Hello 2", Start = DateTime.Now.AddDays(3), End = DateTime.Now.AddDays(3).AddHours(1), Color = "red" },
 
             new AppointmentDto { Title = "Hello 3", Start = DateTime.Today, End = DateTime.Today.AddDays(1), Color = "yellow" },

--- a/DemoApp/Models/AppointmentDto.cs
+++ b/DemoApp/Models/AppointmentDto.cs
@@ -8,5 +8,6 @@ namespace DemoApp.Models
         public DateTime Start { get; set; }
         public DateTime End { get; set; }
         public string Color { get; set; }
+        public string? Class { get; set; }
     }
 }

--- a/DemoApp/Pages/Basic.razor
+++ b/DemoApp/Pages/Basic.razor
@@ -5,7 +5,7 @@
     <Appointments>
         @foreach (var app in _appointments)
         {
-            <Appointment Start="@app.Start" End="@app.End" Color="@app.Color" OnReschedule="(start, end) => HandleReschedule(app, start, end)">
+            <Appointment Start="@app.Start" End="@app.End" Color="@app.Color" OnReschedule="(start, end) => HandleReschedule(app, start, end)" Class="@app.Class">
                 @app.Title
                 @if (context.IsTimed)
                 {

--- a/DemoApp/Pages/Configuration.razor
+++ b/DemoApp/Pages/Configuration.razor
@@ -123,9 +123,4 @@
     {
         _appointments.Clear();
     }
-
-    void RefreshPage()
-    {
-        StateHasChanged();
-    }
 }

--- a/DemoApp/Pages/Configuration.razor
+++ b/DemoApp/Pages/Configuration.razor
@@ -50,6 +50,18 @@
                 <MudTextField @bind-Value="_styles" Label="Custom style (set to every appointment)" />
             </MudItem>
             <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_rootDaysStyles" Label="Custom style (add to global days style)" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_rootAppointmentOverflowStyle" Label="Custom style for overflow appointment (+{n} ...)" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_rootDayClass" Label="Bootstrap classes for root every day in week" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_rootDayStyle" Label="Custom style for every day in week" />
+            </MudItem>
+            <MudItem xs="12" md="6">
                 <MudButton OnClick="AddAppointments" Variant="Variant.Filled" Color="Color.Primary">Add appointments</MudButton>
                 <MudButton OnClick="ClearAppointments" Variant="Variant.Filled" Color="Color.Error">Clear appointments</MudButton>
             </MudItem>
@@ -69,7 +81,10 @@
     TodayButtonText="@_todayButtonText"
     PlusOthersText="@_plusOthersText"
     NewAppointmentText="@_newAppointmentText"
-    EnableAppointmentsCreationFromScheduler="@_enableAppCreationFromScheduler">
+    EnableAppointmentsCreationFromScheduler="@_enableAppCreationFromScheduler" 
+    RootDaysStyle="@_rootDaysStyles" 
+    RootAppointmentOverflowStyle="@_rootAppointmentOverflowStyle" 
+    RootDayClass="@_rootDayClass" RootDayStyle="@_rootDayStyle">
     <Appointments>
         @foreach (var app in _appointments)
         {
@@ -96,8 +111,12 @@
     private string _plusOthersText = "+ {n} others";
     private string _newAppointmentText = "New Appointment";
     
-    private string? _classes = "";
-    private string? _styles = "";
+    private string _classes = "";
+    private string _styles = "";
+    private string _rootDaysStyles = "";
+    private string _rootAppointmentOverflowStyle = "";
+    private string _rootDayClass = "";
+    private string _rootDayStyle = "";
     
     Task OnAddingNewAppointment(DateTime start, DateTime end)
     {

--- a/DemoApp/Pages/Configuration.razor
+++ b/DemoApp/Pages/Configuration.razor
@@ -44,19 +44,19 @@
                 <MudTextField @bind-Value="_newAppointmentText" Label="New Appointment Text" />
             </MudItem>
             <MudItem xs="12" md="6">
-                <MudTextField @bind-Value="_classes" Label="Bootstrap classes (set to every appointment)" />
+                <MudTextField @bind-Value="_classes" Label="Classes (set to every appointment) (eg. could be bootstrap if installed)" />
             </MudItem>
             <MudItem xs="12" md="6">
                 <MudTextField @bind-Value="_styles" Label="Custom style (set to every appointment)" />
             </MudItem>
             <MudItem xs="12" md="6">
-                <MudTextField @bind-Value="_rootDaysStyles" Label="Custom style (add to global days style)" />
+                <MudTextField @bind-Value="_rootDaysGroupInWeekStyles" Label="Custom style (add to global days group style)" />
             </MudItem>
             <MudItem xs="12" md="6">
                 <MudTextField @bind-Value="_rootAppointmentOverflowStyle" Label="Custom style for overflow appointment (+{n} ...)" />
             </MudItem>
             <MudItem xs="12" md="6">
-                <MudTextField @bind-Value="_rootDayClass" Label="Bootstrap classes for root every day in week" />
+                <MudTextField @bind-Value="_rootDayClass" Label="Classes for root every day in weeks (eg. could be bootstrap if installed)" />
             </MudItem>
             <MudItem xs="12" md="6">
                 <MudTextField @bind-Value="_rootDayStyle" Label="Custom style for every day in week" />
@@ -82,7 +82,7 @@
     PlusOthersText="@_plusOthersText"
     NewAppointmentText="@_newAppointmentText"
     EnableAppointmentsCreationFromScheduler="@_enableAppCreationFromScheduler" 
-    RootDaysStyle="@_rootDaysStyles" 
+    RootDaysGroupInWeekStyle="@_rootDaysGroupInWeekStyles" 
     RootAppointmentOverflowStyle="@_rootAppointmentOverflowStyle" 
     RootDayClass="@_rootDayClass" RootDayStyle="@_rootDayStyle">
     <Appointments>
@@ -113,7 +113,7 @@
     
     private string _classes = "";
     private string _styles = "";
-    private string _rootDaysStyles = "";
+    private string _rootDaysGroupInWeekStyles = "";
     private string _rootAppointmentOverflowStyle = "";
     private string _rootDayClass = "";
     private string _rootDayStyle = "";

--- a/DemoApp/Pages/Configuration.razor
+++ b/DemoApp/Pages/Configuration.razor
@@ -44,6 +44,12 @@
                 <MudTextField @bind-Value="_newAppointmentText" Label="New Appointment Text" />
             </MudItem>
             <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_classes" Label="Bootstrap classes (set to every appointment)" />
+            </MudItem>
+            <MudItem xs="12" md="6">
+                <MudTextField @bind-Value="_styles" Label="Custom style (set to every appointment)" />
+            </MudItem>
+            <MudItem xs="12" md="6">
                 <MudButton OnClick="AddAppointments" Variant="Variant.Filled" Color="Color.Primary">Add appointments</MudButton>
                 <MudButton OnClick="ClearAppointments" Variant="Variant.Filled" Color="Color.Error">Clear appointments</MudButton>
             </MudItem>
@@ -67,7 +73,7 @@
     <Appointments>
         @foreach (var app in _appointments)
         {
-            <Appointment Start="@app.Start" End="@app.End" Color="@app.Color" OnReschedule="(start, end) => HandleReschedule(app, start, end)">
+            <Appointment Start="@app.Start" End="@app.End" Color="@app.Color" OnReschedule="(start, end) => HandleReschedule(app, start, end)" Class="@_classes" Style="@_styles">
                 @app.Title
             </Appointment>
         }
@@ -89,7 +95,10 @@
     private string _todayButtonText = "Today";
     private string _plusOthersText = "+ {n} others";
     private string _newAppointmentText = "New Appointment";
-
+    
+    private string? _classes = "";
+    private string? _styles = "";
+    
     Task OnAddingNewAppointment(DateTime start, DateTime end)
     {
         _appointments.Add(new AppointmentDto { Start = start, End = end, Title = "A newly added appointment!", Color = "aqua" });
@@ -113,5 +122,10 @@
     void ClearAppointments()
     {
         _appointments.Clear();
+    }
+
+    void RefreshPage()
+    {
+        StateHasChanged();
     }
 }


### PR DESCRIPTION
- Change appointment text size to a little bit bigger // from 1.2rem to 1.5 rem.
- Modify day height proportionally to text size for good look.
- Add functionallity to set custom classes and styles to appointments // override root style or add classes like bootstrap if needed.
- Add 2 new column to configuration page so user can try setting classes and styles to appointments.